### PR TITLE
Chart for metrics

### DIFF
--- a/src/projectmetrics.lpk
+++ b/src/projectmetrics.lpk
@@ -26,6 +26,7 @@
     <Files>
       <Item>
         <Filename Value="uprojectmetrics.pas"/>
+        <HasRegisterProc Value="True"/>
         <UnitName Value="uProjectMetrics"/>
       </Item>
       <Item>
@@ -34,6 +35,9 @@
       </Item>
     </Files>
     <RequiredPkgs>
+      <Item>
+        <PackageName Value="TAChartLazarusPkg"/>
+      </Item>
       <Item>
         <PackageName Value="IDEIntf"/>
       </Item>

--- a/src/projectmetrics.lpk
+++ b/src/projectmetrics.lpk
@@ -26,7 +26,6 @@
     <Files>
       <Item>
         <Filename Value="uprojectmetrics.pas"/>
-        <HasRegisterProc Value="True"/>
         <UnitName Value="uProjectMetrics"/>
       </Item>
       <Item>

--- a/src/projectmetricsdlg.lfm
+++ b/src/projectmetricsdlg.lfm
@@ -7,9 +7,9 @@ object foProjectMetrics: TfoProjectMetrics
   Caption = 'Project Metrics'
   ClientHeight = 450
   ClientWidth = 870
-  OnCreate = FormCreate
   Position = poScreenCenter
-  LCLVersion = '3.2.0.0'
+  LCLVersion = '4.99.0.0'
+  OnCreate = FormCreate
   object btClose: TButton
     Left = 773
     Height = 25
@@ -33,24 +33,26 @@ object foProjectMetrics: TfoProjectMetrics
     TabOrder = 1
     object tsUsedUnits: TTabSheet
       Caption = 'Used Units'
-      ClientHeight = 369
-      ClientWidth = 847
+      ClientHeight = 380
+      ClientWidth = 845
       object sgUsedUnits: TStringGrid
         AnchorSideRight.Side = asrBottom
         AnchorSideBottom.Side = asrBottom
         Left = 0
-        Height = 370
+        Height = 381
         Top = 0
-        Width = 850
+        Width = 848
         Anchors = [akTop, akLeft, akRight, akBottom]
         ColCount = 7
         DefaultColWidth = 103
         FixedCols = 0
+        Flat = True
         HeaderHotZones = []
         HeaderPushZones = []
-        Options = [goVertLine, goHorzLine, goRangeSelect, goColSizing, goRowSelect, goSmoothScroll]
+        Options = [goRangeSelect, goColSizing, goRowSelect, goThumbTracking, goSmoothScroll]
         RowCount = 2
         TabOrder = 0
+        OnPrepareCanvas = GridPrepareCanvas
         ColWidths = (
           125
           125
@@ -64,24 +66,26 @@ object foProjectMetrics: TfoProjectMetrics
     end
     object tsInspectorUnits: TTabSheet
       Caption = 'Inspector Units'
-      ClientHeight = 369
-      ClientWidth = 847
+      ClientHeight = 380
+      ClientWidth = 845
       object sgInspectorUnits: TStringGrid
         AnchorSideRight.Side = asrBottom
         AnchorSideBottom.Side = asrBottom
         Left = 0
-        Height = 370
+        Height = 381
         Top = 0
-        Width = 850
+        Width = 848
         Anchors = [akTop, akLeft, akRight, akBottom]
         ColCount = 7
         DefaultColWidth = 103
         FixedCols = 0
+        Flat = True
         HeaderHotZones = []
         HeaderPushZones = []
-        Options = [goVertLine, goHorzLine, goRangeSelect, goColSizing, goRowSelect, goSmoothScroll]
+        Options = [goRangeSelect, goColSizing, goRowSelect, goThumbTracking, goSmoothScroll]
         RowCount = 2
         TabOrder = 0
+        OnPrepareCanvas = GridPrepareCanvas
         ColWidths = (
           125
           125

--- a/src/projectmetricsdlg.lfm
+++ b/src/projectmetricsdlg.lfm
@@ -27,41 +27,82 @@ object foProjectMetrics: TfoProjectMetrics
     Height = 408
     Top = 8
     Width = 853
-    ActivePage = tsInspectorUnits
+    ActivePage = tsUsedUnits
     Anchors = [akTop, akLeft, akRight, akBottom]
-    TabIndex = 1
+    TabIndex = 0
     TabOrder = 1
+    OnChange = pcProjectMetricsChange
     object tsUsedUnits: TTabSheet
       Caption = 'Used Units'
       ClientHeight = 380
       ClientWidth = 845
       object sgUsedUnits: TStringGrid
-        AnchorSideRight.Side = asrBottom
-        AnchorSideBottom.Side = asrBottom
         Left = 0
-        Height = 381
+        Height = 380
         Top = 0
-        Width = 848
-        Anchors = [akTop, akLeft, akRight, akBottom]
-        ColCount = 7
+        Width = 845
+        Align = alClient
+        ColCount = 0
         DefaultColWidth = 103
         FixedCols = 0
+        FixedRows = 0
         Flat = True
         HeaderHotZones = []
         HeaderPushZones = []
         Options = [goRangeSelect, goColSizing, goRowSelect, goThumbTracking, goSmoothScroll]
-        RowCount = 2
+        RowCount = 0
         TabOrder = 0
         OnPrepareCanvas = GridPrepareCanvas
-        ColWidths = (
-          125
-          125
-          125
-          125
-          125
-          125
-          124
+      end
+      object MetricsChart: TChart
+        Left = 64
+        Height = 194
+        Top = 104
+        Width = 244
+        AxisList = <        
+          item
+            Grid.Color = clSilver
+            Grid.Style = psSolid
+            Marks.LabelBrush.Style = bsClear
+            Minors = <>
+            Title.LabelFont.Orientation = 900
+            Title.LabelFont.Style = [fsBold]
+            Title.Visible = True
+            Title.Caption = 'Lines'
+            Title.LabelBrush.Style = bsClear
+          end        
+          item
+            Grid.Visible = False
+            TickLength = 0
+            Alignment = calBottom
+            Marks.Distance = 8
+            Marks.LabelBrush.Style = bsClear
+            Marks.RotationCenter = rcEdge
+            Minors = <            
+              item
+                Grid.Visible = False
+                Intervals.Count = 1
+                Intervals.MinLength = 5
+                Intervals.Options = [aipUseCount, aipUseMinLength]
+                TickLength = 4
+                Marks.LabelBrush.Style = bsClear
+              end>
+            Title.LabelBrush.Style = bsClear
+          end>
+        Legend.Alignment = laBottomCenter
+        Legend.ColumnCount = 3
+        Legend.Visible = True
+        Margins.Bottom = 0
+        Title.Text.Strings = (
+          'TAChart'
         )
+        Toolset = ChartToolset
+        Visible = False
+        object MetricsBarSeries: TBarSeries
+          Legend.Multiplicity = lmStyle
+          BarBrush.Color = clRed
+          Styles = ChartStyles
+        end
       end
     end
     object tsInspectorUnits: TTabSheet
@@ -69,13 +110,11 @@ object foProjectMetrics: TfoProjectMetrics
       ClientHeight = 380
       ClientWidth = 845
       object sgInspectorUnits: TStringGrid
-        AnchorSideRight.Side = asrBottom
-        AnchorSideBottom.Side = asrBottom
         Left = 0
-        Height = 381
+        Height = 380
         Top = 0
-        Width = 848
-        Anchors = [akTop, akLeft, akRight, akBottom]
+        Width = 845
+        Align = alClient
         ColCount = 7
         DefaultColWidth = 103
         FixedCols = 0
@@ -110,5 +149,83 @@ object foProjectMetrics: TfoProjectMetrics
     ShowHint = True
     TabOrder = 2
     OnClick = btCopyToClipboardClick
+  end
+  object rbTable: TRadioButton
+    AnchorSideLeft.Control = pcProjectMetrics
+    AnchorSideTop.Control = btClose
+    AnchorSideTop.Side = asrCenter
+    Left = 8
+    Height = 19
+    Top = 420
+    Width = 47
+    Caption = 'Table'
+    Checked = True
+    TabOrder = 3
+    TabStop = True
+    OnChange = rbTableChange
+  end
+  object rbChart: TRadioButton
+    AnchorSideLeft.Control = rbTable
+    AnchorSideLeft.Side = asrBottom
+    AnchorSideTop.Control = btClose
+    AnchorSideTop.Side = asrCenter
+    Left = 71
+    Height = 19
+    Top = 420
+    Width = 47
+    BorderSpacing.Left = 16
+    Caption = 'Chart'
+    TabOrder = 4
+    OnChange = rbTableChange
+  end
+  object ChartStyles: TChartStyles
+    Styles = <    
+      item
+        Brush.Color = 8799488
+        Text = 'Code lines'
+      end    
+      item
+        Brush.Color = 934655
+        Text = 'Comment lines'
+      end    
+      item
+        Brush.Color = 2151423
+        Text = 'Empty lines'
+      end>
+    Left = 376
+    Top = 64
+  end
+  object lcsUsedUnits: TListChartSource
+    YCount = 3
+    Left = 75
+    Top = 64
+  end
+  object lcsInspectorUnits: TListChartSource
+    YCount = 3
+    Left = 199
+    Top = 64
+  end
+  object ChartToolset: TChartToolset
+    Left = 480
+    Top = 64
+    object DataPointHintTool: TDataPointHintTool
+      OnHint = DataPointHintToolHint
+      OnHintLocation = DataPointHintToolHintLocation
+      UseDefaultHintText = False
+    end
+    object MouseWheelZoomTool: TZoomMouseWheelTool
+      LimitToExtent = [zdLeft, zdUp, zdRight, zdDown]
+      ZoomFactor = 1.1
+      ZoomRatio = 0.909
+    end
+    object ZoomDragTool: TZoomDragTool
+      Shift = [ssLeft]
+      LimitToExtent = [zdLeft, zdUp, zdRight, zdDown]
+      Brush.Style = bsClear
+    end
+    object PanDragTool: TPanDragTool
+      Shift = [ssRight]
+      LimitToExtent = [pdLeft, pdUp, pdRight, pdDown]
+    end
   end
 end

--- a/src/projectmetricsdlg.pas
+++ b/src/projectmetricsdlg.pas
@@ -250,25 +250,66 @@ begin
 end;
 
 procedure TfoProjectMetrics.InitializeGrid(grid: TStringGrid);
+const
+  W = 110;
 begin
-  grid.ColCount := 7;
   grid.RowCount := 2;
   grid.FixedRows := 1;
   grid.FixedCols := 0;
-  grid.Cells[0, 0] := 'File Name';
-  grid.Cells[1, 0] := 'Non-Empty Lines';
-  grid.Cells[2, 0] := 'Code Lines';
-  grid.Cells[3, 0] := 'Comment Lines';
-  grid.Cells[4, 0] := 'Empty Lines';
-  grid.Cells[5, 0] := 'Comment %';
-  grid.Cells[6, 0] := 'Empty %';
-  grid.ColWidths[0] := 180; // Wider for file names
-  grid.ColWidths[1] := 110;
-  grid.ColWidths[2] := 110;
-  grid.ColWidths[3] := 110;
-  grid.ColWidths[4] := 110;
-  grid.ColWidths[5] := 110;
-  grid.ColWidths[6] := 110;
+  grid.Columns.Clear;
+  with grid.Columns.Add do
+  begin
+    Title.Caption := 'File Name';
+  end;
+  with grid.Columns.Add do
+  begin
+    Title.Caption := 'Non-Empty Lines';
+    Title.Alignment := taRightJustify;
+    Width := W;
+    SizePriority := 0;
+    Alignment := taRightJustify;
+  end;
+  with grid.Columns.Add do
+  begin
+    Title.Caption := 'Code Lines';
+    Title.Alignment := taRightJustify;
+    Width := W;
+    SizePriority := 0;
+    Alignment := taRightJustify;
+  end;
+  with grid.Columns.Add do
+  begin
+    Title.Caption := 'Comment Lines';
+    Title.Alignment := taRightJustify;
+    Width := W;
+    SizePriority := 0;
+    Alignment := taRightJustify;
+  end;
+  with grid.Columns.Add do
+  begin
+    Title.Caption := 'Empty Lines';
+    Title.Alignment := taRightJustify;
+    SizePriority := 0;
+    Width := W;
+    Alignment := taRightJustify;
+  end;
+  with grid.Columns.Add do
+  begin
+    Title.Caption := 'Comment %';
+    Title.Alignment := taRightJustify;
+    SizePriority := 0;
+    Width := W;
+    Alignment := taRightJustify;
+  end;
+  with grid.Columns.Add do
+  begin
+    Title.Caption := 'Empty %';
+    Title.Alignment := taRightJustify;
+    SizePriority := 0;
+    Width := W;
+    Alignment := taRightJustify;
+  end;
+  grid.AutoFillColumns := true;
 end;
 
 procedure TfoProjectMetrics.GetResults(prjUnits: TProjectUnits;

--- a/src/projectmetricsdlg.pas
+++ b/src/projectmetricsdlg.pas
@@ -44,12 +44,6 @@ type
     LfmFilesTotal: TSourceFile;
   end;
 
-  // interposer class overrides DrawCell
-  TStringGrid = class(Grids.TStringGrid)
-    protected
-    procedure DrawCell(ACol, ARow: Longint; ARect: TRect; AState: TGridDrawState); override;
-  end;
-
   { TfoProjectMetrics }
 
   TfoProjectMetrics = class(TForm)
@@ -63,6 +57,8 @@ type
     procedure btCloseClick(Sender: TObject);
     procedure btCopyToClipboardClick(Sender: TObject);
     procedure FormCreate(Sender: TObject);
+    procedure GridPrepareCanvas(Sender: TObject; aCol, aRow: Integer;
+      aState: TGridDrawState);
   private
     CountLineStatus: integer;
     MetricsPerFile: TStringList;
@@ -79,23 +75,6 @@ type
   end;
 
 implementation
-
-// interposer class to right-align cell text
-procedure TStringGrid.DrawCell(ACol, ARow: Integer; ARect: TRect; AState: TGridDrawState);
-var
-  s: string;
-  a: integer;
-begin
-  // just not the first column
-  if (ACol > 0) then
-    begin
-      s := Cells[ACol, ARow];
-      a := ColWidths[ACol] - Canvas.TextWidth(s);
-      Canvas.TextRect(ARect, ARect.Left + a, ARect.Top + 2, s);
-    end
-  else
-    Canvas.TextRect(ARect, ARect.Left + 2, ARect.Top + 2, Cells[ACol, ARow]);
-end;
 
 {$R *.lfm}
 
@@ -380,6 +359,19 @@ begin
   sgInspectorUnits.Font.Name := GRID_FONT_NAME;
   sgInspectorUnits.Font.Size := GRID_FONT_SIZE;
   pcProjectMetrics.ActivePageIndex := 0;
+end;
+
+procedure TfoProjectMetrics.GridPrepareCanvas(Sender: TObject;
+  aCol, aRow: Integer; aState: TGridDrawState);
+var
+  grid: TStringGrid;
+  textStyle: TTextStyle;
+begin
+  grid := Sender as TStringGrid;
+  textStyle := grid.Canvas.TextStyle;
+  if aCol > 0 then
+    textStyle.Alignment := taRightJustify;
+  grid.Canvas.TextStyle := textStyle;
 end;
 
 procedure TfoProjectMetrics.Analyze(AUnits, AInspectorUnits: TStrings);

--- a/src/uprojectmetrics.pas
+++ b/src/uprojectmetrics.pas
@@ -13,7 +13,7 @@ unit uProjectMetrics;
 
 interface
 
-uses Classes, SysUtils, LazIDEIntf, MenuIntf, ProjectMetricsDlg;
+uses Classes, SysUtils, LazIDEIntf, MenuIntf, ProjectIntf, ProjectMetricsDlg;
 
 procedure Register;
 
@@ -22,11 +22,31 @@ implementation
 procedure MyMenuItemClick(Sender: TObject);
 var
   fo: TfoProjectMetrics;
+  LazProject: TLazProject;
+  LazFile: TLazProjectFile;
+  Units: TStrings = nil;
+  InspectorUnits: TStrings = nil;
+  i: Integer;
 begin
   fo := TfoProjectMetrics.Create(nil);
   try
+    LazProject := LazarusIDE.ActiveProject;
+    if LazProject <> nil then
+    begin
+      Units := LazarusIDE.FindUnitsOfOwner(LazProject, [fuooListed, fuooUsed]);
+      InspectorUnits := TStringList.Create;
+      for i := 0 to LazProject.FileCount - 1 do
+      begin
+        LazFile := LazProject.Files[i];
+        if LazFile.IsPartOfProject then
+          InspectorUnits.Add(LazProject.Files[i].FileName);
+      end;
+    end;
+    fo.Analyze(Units, InspectorUnits);
     fo.ShowModal;
   finally
+    InspectorUnits.Free;
+    Units.Free;
     fo.Free;
   end;
 end;


### PR DESCRIPTION
I think it is quit illustrative to have a chart with the metrics data in the form. Therefore I added a TChart with stacked bar series; stack levels are the code/comments/empty line count of each file.

Additionally I also introduced columns for the grids since they allow easier control over the column widths in a way that the entire grid client width is filled by columns. And it also simplifies right-aligning text which finally results in the possibility to drop the sub-classed stringgrid.

And I removed the IDE-related units out off the ProjectMetricsDlg in order to facilitate development and debugging without having to recompile the IDE.

BTW: What do you mean with "inspector units"?
